### PR TITLE
add azure redis cache support in terraform deployment

### DIFF
--- a/terraform/modules/nxs-oss/aks_configs/main.tf
+++ b/terraform/modules/nxs-oss/aks_configs/main.tf
@@ -155,7 +155,7 @@ spec:
       type: Opaque
   YAML
   depends_on = [
-    kubernetes_namespace.nxs_ns
+    kubernetes_namespace.nxs_ns, var.redis_address
   ]
 }
 

--- a/terraform/modules/nxs-oss/aks_configs/variables.tf
+++ b/terraform/modules/nxs-oss/aks_configs/variables.tf
@@ -66,3 +66,7 @@ variable acr_user_name {
 variable acr_password {
     type = string
 }
+
+variable redis_address {
+    type = string
+}

--- a/terraform/modules/nxs-oss/redis_cache/main.tf
+++ b/terraform/modules/nxs-oss/redis_cache/main.tf
@@ -15,6 +15,7 @@ resource "random_password" "redis_name_suffix" {
 }
 
 resource "azurerm_redis_cache" "nxs_redis" {
+  count = var.create_module ? 1 : 0
   provider            = azurerm.user_subscription
   name                = lower(substr("nxs-${var.base.deployment_name}-redis-${random_password.redis_name_suffix.result}", 0, 24))
   location            = var.base.location
@@ -32,17 +33,17 @@ resource "azurerm_redis_cache" "nxs_redis" {
 }
 
 output redis_address {
-  value = azurerm_redis_cache.nxs_redis.hostname
+  value = var.create_module ? azurerm_redis_cache.nxs_redis[0].hostname : ""
 }
 
 output redis_port {
-  value = azurerm_redis_cache.nxs_redis.ssl_port
+  value = var.create_module ? azurerm_redis_cache.nxs_redis[0].ssl_port : 6380
 }
 
 output redis_password {
-  value = azurerm_redis_cache.nxs_redis.primary_access_key
+  value = var.create_module ? azurerm_redis_cache.nxs_redis[0].primary_access_key : ""
 }
 
 output redis_use_ssl {
-    value = "true"
+  value = "true"
 }

--- a/terraform/modules/nxs-oss/redis_cache/variables.tf
+++ b/terraform/modules/nxs-oss/redis_cache/variables.tf
@@ -20,3 +20,8 @@ variable az_redis_cache_sku {
   description = "Azure Redis Cache SKU Type"
   default     = "Standard"
 }
+
+variable create_module {
+  type = bool
+  description = "Enable or disable this module"
+}

--- a/terraform/modules/nxs-oss/redis_oss/main.tf
+++ b/terraform/modules/nxs-oss/redis_oss/main.tf
@@ -28,6 +28,7 @@ provider "kubectl" {
 
 # create redis-operator namespace
 resource "kubernetes_namespace" "redis_operator_ns" {
+  count = var.create_module ? 1 : 0
   metadata {
     name = "redis-operator"
     labels = {
@@ -38,12 +39,14 @@ resource "kubernetes_namespace" "redis_operator_ns" {
 
 # create ot-operators namespace
 resource "kubernetes_namespace" "ot_operator_ns" {
+  count = var.create_module ? 1 : 0
   metadata {
     name = "ot-operators"
   }
 }
 
 resource "kubectl_manifest" "redis_step1" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = file("${path.module}/yaml/redis.redis.opstreelabs.in_redis.yaml")
@@ -54,6 +57,7 @@ resource "kubectl_manifest" "redis_step1" {
 }
 
 resource "kubectl_manifest" "redis_step2" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = file("${path.module}/yaml/redis.redis.opstreelabs.in_redisclusters.yaml")
@@ -64,6 +68,7 @@ resource "kubectl_manifest" "redis_step2" {
 }
 
 resource "kubectl_manifest" "redis_step3" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = file("${path.module}/yaml/serviceaccount.yaml")
@@ -74,6 +79,7 @@ resource "kubectl_manifest" "redis_step3" {
 }
 
 resource "kubectl_manifest" "redis_step4" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = file("${path.module}/yaml/role.yaml")
@@ -84,6 +90,7 @@ resource "kubectl_manifest" "redis_step4" {
 }
 
 resource "kubectl_manifest" "redis_step5" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = file("${path.module}/yaml/role_binding.yaml")
@@ -94,6 +101,7 @@ resource "kubectl_manifest" "redis_step5" {
 }
 
 resource "kubectl_manifest" "redis_step6" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = file("${path.module}/yaml/manager.yaml")
@@ -112,6 +120,7 @@ resource "random_password" "redis_password" {
 }
 
 resource "kubectl_manifest" "redis_conf" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = templatefile("${path.module}/yaml/redis_conf.yaml",
@@ -126,6 +135,7 @@ resource "kubectl_manifest" "redis_conf" {
 }
 
 resource "kubectl_manifest" "redis_server" {
+  count = var.create_module ? 1 : 0
   wait = true
   wait_for_rollout = true
   yaml_body = templatefile("${path.module}/yaml/redis_standalone.yaml",
@@ -141,7 +151,7 @@ resource "kubectl_manifest" "redis_server" {
 }
 
 output redis_address {
-  value = "redis-standalone.ot-operators"
+  value = var.create_module ? "redis-standalone.ot-operators" : ""
   depends_on = [kubectl_manifest.redis_server]
 }
 
@@ -151,11 +161,11 @@ output redis_port {
 }
 
 output redis_password {
-  value = random_password.redis_password.result
+  value = var.create_module ? random_password.redis_password.result : ""
   depends_on = [kubectl_manifest.redis_server]
 }
 
 output redis_use_ssl {
-    value = "false"
-    depends_on = [kubectl_manifest.redis_server]
+  value = "false"
+  depends_on = [kubectl_manifest.redis_server]
 }

--- a/terraform/modules/nxs-oss/redis_oss/variables.tf
+++ b/terraform/modules/nxs-oss/redis_oss/variables.tf
@@ -38,3 +38,8 @@ variable redis_memory_per_node {
   description = "Memory allocated to single node in redis cluster"
   default     = "2Gi"
 }
+
+variable create_module {
+  type = bool
+  description = "Enable or disable this module"
+}

--- a/terraform/modules/nxs-oss/root/variables.tf
+++ b/terraform/modules/nxs-oss/root/variables.tf
@@ -109,6 +109,12 @@ variable enable_api_v1 {
   default     = true
 }
 
+variable use_azure_redis_cache {
+  type = bool
+  description = "Use Azure Redis Cache instead of OSS Redis"
+  default     = false
+}
+
 variable acr_login_server {
   type = string
   description = "Azure container registry server"


### PR DESCRIPTION
Add:
- Support for Azure Redis Cache
- Flag "use_azure_redis_cache" to switch between Azure Redis Cache and OSS Redis 